### PR TITLE
Add delete_destination_volume option to snapmirror resource

### DIFF
--- a/examples/snapmirror/resources.tf
+++ b/examples/snapmirror/resources.tf
@@ -68,4 +68,5 @@ resource "netapp-cloudmanager_snapmirror" "cl-snapmirror" {
   schedule = "5min"
   source_volume_name = netapp-cloudmanager_volume.cvo-volume2.name
   source_working_environment_id = netapp-cloudmanager_cvo_aws.cvo-aws-2.id
+  delete_destination_volume = true  # Enable automatic deletion of destination volume when snapmirror is destroyed
 }

--- a/website/docs/r/snapmirror.html.markdown
+++ b/website/docs/r/snapmirror.html.markdown
@@ -31,6 +31,26 @@ resource "netapp-cloudmanager_snapmirror" "cl-snapmirror" {
 }
 ```
 
+**Create netapp-cloudmanager_snapmirror with automatic destination volume deletion:**
+
+```
+resource "netapp-cloudmanager_snapmirror" "cl-snapmirror-with-volume-deletion" {
+  provider = netapp-cloudmanager
+  source_working_environment_id = "xxxxxxxx"
+  destination_working_environment_id = "xxxxxxxx"
+  source_volume_name = "source"
+  source_svm_name = "svm_source"
+  destination_volume_name = "source_copy"
+  destination_svm_name = "svm_dest"
+  policy = "MirrorAllSnapshots"
+  schedule = "5min"
+  destination_aggregate_name = "aggr1"
+  max_transfer_rate = "102400"
+  delete_destination_volume = true
+  client_id = "xxxxxxxxxxx"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -53,6 +73,7 @@ The following arguments are supported:
 * `destination_aggregate_name` - (Optional) The aggregate in which the volume will be created. If not provided, Cloud Manager chooses the best aggregate for you.
 * `provider_volume_type` - (Optional) The underlying cloud provider volume type. For AWS: ['gp3', 'gp2', 'io1', 'st1', 'sc1']. For Azure: ['Premium_LRS','Standard_LRS','StandardSSD_LRS']. For GCP: ['pd-balanced', 'pd-ssd','pd-standard']
 * `capacity_tier` - (Optional) The volume's capacity tier for tiering cold data to object storage: ['S3', 'Blob', 'cloudStorage']. The default values for each cloud provider are as follows: Amazon => 'S3', Azure => 'Blob', GCP => 'cloudStorage'. If none, the capacity tier won't be set on volume creation.
+* `delete_destination_volume` - (Optional) Set to true to delete the destination volume when the snapmirror relationship is destroyed. The default is false.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Add new optional parameter delete_destination_volume (default: false)
- When enabled, automatically deletes destination volume after snapmirror deletion
- Reuses existing volume deletion logic for consistency
- Update documentation and examples
- Maintains backward compatibility

This enhancement allows users to automatically clean up destination volumes when destroying snapmirror relationships, preventing orphaned resources while maintaining backward compatibility with existing configurations.