### PR TITLE
fix replication import

### DIFF
--- a/cloudmanager/resource_netapp_cloudmanager_snapmirror.go
+++ b/cloudmanager/resource_netapp_cloudmanager_snapmirror.go
@@ -1,6 +1,7 @@
 package cloudmanager
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -16,7 +17,7 @@ func resourceCVOSnapMirror() *schema.Resource {
 		Exists: resourceCVOSnapMirrorExists,
 		Update: resourceCVOSnapMirrorUpdate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceCVOSnapMirrorImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"source_working_environment_id": {
@@ -315,4 +316,87 @@ func resourceCVOSnapMirrorExists(d *schema.ResourceData, meta interface{}) (bool
 func resourceCVOSnapMirrorUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	return nil
+}
+
+func resourceCVOSnapMirrorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("Importing SnapMirror with ID: %s", d.Id())
+
+	client := meta.(*Client)
+	importID := d.Id()
+
+	// Parse the import ID - expect format: client_id:destination_volume_name
+	parts := strings.Split(importID, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid import ID format. Expected: client_id:destination_volume_name, got: %s", importID)
+	}
+
+	clientID := parts[0]
+	destinationVolumeName := parts[1]
+
+	// Check deployment mode
+	isSaas, connectorIP, err := client.checkDeploymentMode(d, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check deployment mode during import: %v", err)
+	}
+
+	// Try to find the snapmirror relationship by destination volume name
+	relationship, err := client.findSnapMirrorByDestinationVolume(destinationVolumeName, clientID, isSaas, connectorIP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find snapmirror relationship during import: %v", err)
+	}
+
+	// Set the ID and populate the required fields
+	d.SetId(destinationVolumeName)
+	d.Set("client_id", clientID)
+	d.Set("source_working_environment_id", relationship.Source.WorkingEnvironmentID)
+	d.Set("destination_working_environment_id", relationship.Destination.WorkingEnvironmentID)
+	d.Set("source_volume_name", relationship.Source.VolumeName)
+	d.Set("destination_volume_name", relationship.Destination.VolumeName)
+	d.Set("source_svm_name", relationship.Source.SvmName)
+	d.Set("destination_svm_name", relationship.Destination.SvmName)
+	d.Set("policy", relationship.Policy)
+	d.Set("schedule", relationship.Schedule)
+	d.Set("max_transfer_rate", relationship.MaxTransferRate.Size)
+
+	// Set default values for fields that have them in the schema
+	d.Set("deployment_mode", "Standard")
+	d.Set("delete_destination_volume", false)
+
+	// Set optional fields if they exist, otherwise set appropriate defaults
+	if relationship.Destination.AggregateName != "" {
+		d.Set("destination_aggregate_name", relationship.Destination.AggregateName)
+	}
+	if relationship.Destination.ProviderVolumeType != "" {
+		d.Set("provider_volume_type", relationship.Destination.ProviderVolumeType)
+	}
+	if relationship.Destination.CapacityTier != "" && relationship.Destination.CapacityTier != "none" {
+		d.Set("capacity_tier", relationship.Destination.CapacityTier)
+	} else {
+		d.Set("capacity_tier", "none")
+	}
+
+	// Try to get additional volume information from the destination working environment
+	// This is needed because the status API doesn't include all volume details
+	if relationship.Destination.WorkingEnvironmentID != "" {
+		volumeRequest := volumeRequest{
+			WorkingEnvironmentID: relationship.Destination.WorkingEnvironmentID,
+			Name:                 relationship.Destination.VolumeName,
+		}
+
+		volumes, err := client.getVolume(volumeRequest, clientID, isSaas, connectorIP)
+		if err == nil && len(volumes) > 0 {
+			volume := volumes[0]
+			if volume.AggregateName != "" {
+				d.Set("destination_aggregate_name", volume.AggregateName)
+			}
+			if volume.ProviderVolumeType != "" {
+				d.Set("provider_volume_type", volume.ProviderVolumeType)
+			}
+			if volume.CapacityTier != "" {
+				d.Set("capacity_tier", volume.CapacityTier)
+			}
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the NetApp Cloud Manager SnapMirror resource, primarily focusing on adding import functionality and improving the handling of SnapMirror relationships. The most important changes include implementing a new import function, refactoring data structures for SnapMirror relationships, and adding helper methods to query and filter SnapMirror data.

### Import Functionality
* Added `resourceCVOSnapMirrorImport` to enable importing SnapMirror relationships by parsing an import ID and populating resource fields with data retrieved from the API. This includes support for default values and optional fields. (`cloudmanager/resource_netapp_cloudmanager_snapmirror.go`, [cloudmanager/resource_netapp_cloudmanager_snapmirror.goR320-R402](diffhunk://#diff-20515c43c24562868574794cac4917e54f395550be850d018ecc22fbceed29dfR320-R402))
* Updated the `Importer` configuration in `resourceCVOSnapMirror` to use the new `resourceCVOSnapMirrorImport` function instead of `schema.ImportStatePassthrough`. (`cloudmanager/resource_netapp_cloudmanager_snapmirror.go`, [cloudmanager/resource_netapp_cloudmanager_snapmirror.goL19-R20](diffhunk://#diff-20515c43c24562868574794cac4917e54f395550be850d018ecc22fbceed29dfL19-R20))

### Data Structure Enhancements
* Replaced the `destination` struct with a more comprehensive `relationshipEndpoint` struct, which includes additional fields like `WorkingEnvironmentType`, `ClusterName`, and `Region`. This allows for more detailed representation of SnapMirror relationships. (`cloudmanager/snapmirror.go`, [cloudmanager/snapmirror.goL52-R92](diffhunk://#diff-d1f0e7f223f6d422fa0aeaec2f2317efad27e482b546313c728ec233f6b07e93L52-R92))

### API Query Enhancements
* Added `getAllSnapMirrorRelationships` to retrieve all SnapMirror relationships and filter them based on the destination volume. (`cloudmanager/snapmirror.go`, [cloudmanager/snapmirror.goR358-R456](diffhunk://#diff-d1f0e7f223f6d422fa0aeaec2f2317efad27e482b546313c728ec233f6b07e93R358-R456))
* Introduced `getSnapMirrorStatusForSourceWE` to fetch detailed SnapMirror status for a specific source working environment. (`cloudmanager/snapmirror.go`, [cloudmanager/snapmirror.goR358-R456](diffhunk://#diff-d1f0e7f223f6d422fa0aeaec2f2317efad27e482b546313c728ec233f6b07e93R358-R456))
* Added `findSnapMirrorByDestinationVolume` to locate a specific SnapMirror relationship by its destination volume name. (`cloudmanager/snapmirror.go`, [cloudmanager/snapmirror.goR358-R456](diffhunk://#diff-d1f0e7f223f6d422fa0aeaec2f2317efad27e482b546313c728ec233f6b07e93R358-R456))

### Minor Changes
* Imported the `fmt` package to handle formatted error messages and logging. (`cloudmanager/resource_netapp_cloudmanager_snapmirror.go`, [cloudmanager/resource_netapp_cloudmanager_snapmirror.goR4](diffhunk://#diff-20515c43c24562868574794cac4917e54f395550be850d018ecc22fbceed29dfR4))